### PR TITLE
Avoid non-initializing wallets

### DIFF
--- a/src/@terra-money/wallet-kit/WalletProvider.tsx
+++ b/src/@terra-money/wallet-kit/WalletProvider.tsx
@@ -29,17 +29,17 @@ interface WalletProviderProps {
 
 type WalletProviderState =
   | {
-      status: WalletStatus.CONNECTED
-      wallet: Wallet
-      connectedWallet: ConnectResponse
-      network: InfoResponse
-    }
+    status: WalletStatus.CONNECTED
+    wallet: Wallet
+    connectedWallet: ConnectResponse
+    network: InfoResponse
+  }
   | {
-      status: WalletStatus.INITIALIZING | WalletStatus.NOT_CONNECTED
-      network: InfoResponse
-      wallet?: undefined
-      connectedWallet?: undefined
-    }
+    status: WalletStatus.INITIALIZING | WalletStatus.NOT_CONNECTED
+    network: InfoResponse
+    wallet?: undefined
+    connectedWallet?: undefined
+  }
 
 function WalletProvider({
   children,
@@ -59,18 +59,23 @@ function WalletProvider({
       connectedID && availableWallets.find(({ id }) => id === connectedID)
 
     if (wallet) {
-      ;(async () => {
-        const [connectedWallet, network] = await Promise.all([
-          wallet.connect(),
-          wallet.info(),
-        ])
+      ; (async () => {
 
-        setState({
-          status: WalletStatus.CONNECTED,
-          wallet,
-          connectedWallet,
-          network,
-        })
+        try {
+          const [connectedWallet, network] = await Promise.all([
+            wallet.connect(),
+            wallet.info(),
+          ])
+
+          setState({
+            status: WalletStatus.CONNECTED,
+            wallet,
+            connectedWallet,
+            network,
+          })
+        } catch (error) {
+          console.error("Error while connecting wallet on startup", error)
+        }
       })()
 
       const networkCallback = (network: InfoResponse) => {


### PR DESCRIPTION
This PR aims at avoiding initialization errors caused by wallets.

# Rationale
On a webpage that was already connected to a wallet (if `__wallet_kit_connected_wallet` is set in localstorage), when refreshing the page, the connection to this wallet is triggered on page startup.
However, if anything in this startup fails, wallet-kit stays in INITIALIZED mode and the loading of any other wallet won't work. 

# Proposed solution
If an error is thrown during wallet startup or info query on initial wallet connection, the wallet is not connected but the WalletProvider startup is not interrupted and can continue. This allows errors during first initialization (for instance if the wallet password is not indicated correctly)

# Current Use case where it's needed
I implemented a local wallet for my Webapp (for easier on-boarding). Once my user is connected, if they fail to give their password (for instance if it's forgotten), the webpage won't be able to connect any wallet anymore. They are facing a blocked state due to wallet-kit not being able to initialize correctly.